### PR TITLE
Use a staging array to have better cache locality for long reads.

### DIFF
--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -875,6 +875,7 @@ QCMetrics__new__(PyTypeObject *type, PyObject *args, PyObject *kwargs){
     self->max_length = 0;
     self->phred_offset = phred_offset;
     self->count_tables = NULL;
+    self->staging_count_tables = NULL;
     self->number_of_reads = 0;
     memset(self->gc_content, 0, 101 * sizeof(uint64_t));
     memset(self->phred_scores, 0, (PHRED_MAX + 1) * sizeof(uint64_t));

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -833,6 +833,8 @@ typedef uint64_t counttable_t[PHRED_TABLE_SIZE][NUC_TABLE_SIZE];
    count array when 65535 entries are counted in the uint16_t staging array.
    For short reads, this is mainly extra work and therefore has a very small
    penalty. For long reads it is very beneficial.
+   uint8_t was also tested but that made things a lot slower for long reads
+   due to having to transverse the count arrays very frequently.
 */
 typedef uint16_t staging_counttable_t[PHRED_TABLE_SIZE][NUC_TABLE_SIZE];
 

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -954,6 +954,7 @@ QCMetrics_add_meta(QCMetrics *self, struct FastqMeta *meta)
             QCMetrics_flush_staging(self);
         }   
         self->staging_count += 1;
+        staging_counttable_t *staging_count_tables = self->staging_count_tables;
         for (size_t i=0; i < (size_t)sequence_length; i+=1) {
             uint8_t c = sequence[i];
             uint8_t q = qualities[i] - phred_offset;
@@ -966,11 +967,12 @@ QCMetrics_add_meta(QCMetrics *self, struct FastqMeta *meta)
             }
             uint8_t q_index = phred_to_index(q);
             uint8_t c_index = NUCLEOTIDE_TO_INDEX[c];
-            self->staging_count_tables[i][q_index][c_index] += 1;
+            staging_count_tables[i][q_index][c_index] += 1;
             base_counts[c_index] += 1;
             accumulated_error_rate += SCORE_TO_ERROR_RATE[q];
         }
     } else {
+        counttable_t *count_tables = self->count_tables;
         for (size_t i=0; i < (size_t)sequence_length; i+=1) {
             uint8_t c = sequence[i];
             uint8_t q = qualities[i] - phred_offset;
@@ -983,7 +985,7 @@ QCMetrics_add_meta(QCMetrics *self, struct FastqMeta *meta)
             }
             uint8_t q_index = phred_to_index(q);
             uint8_t c_index = NUCLEOTIDE_TO_INDEX[c];
-            self->count_tables[i][q_index][c_index] += 1;
+            count_tables[i][q_index][c_index] += 1;
             base_counts[c_index] += 1;
             accumulated_error_rate += SCORE_TO_ERROR_RATE[q];
         }


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

A uint64_t count array is needed to collect all the metrics. However when a lot of reads approach L2 cache size / (60 * 8) a lot of L2 cache misses will occur. L2 cache is 512KB per core on later ryzen models. So that means reads that are significantly longer than 1000 fall in this category. By using a uint16_t staging array, the reads have to be longer than 4000, which is a significantly smaller proportion of the reads for nanopore. The staging array can be be used to increment the uint64_t count array every 65535 counts, which is not very much. 
uint8_t did not work, because updating every 255 counts was more work than what was saved in L2 cache misses. 

For illumina this is not really a benefit as the count array always fits in L2 most of the times, so the algorithm dynamically chooses to use a staging array based on maximum read length acquired. 

SRR15096500_1.fastq.gz now only takes 45 seconds runtime to analyze as opposed to 60 seconds. There is no measurable effect on illumina (as expected the algorithm should always avoid the staging array).