### PR TITLE
Titleparse

### DIFF
--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1856,9 +1856,7 @@ ssize_t illumina_header_to_tile_id(const uint8_t *header, size_t header_length) 
     size_t remaining_length = header_length - tile_number_offset;
     for (size_t i=0; i < remaining_length; i++) {
         uint8_t c = tile_start[i];
-        /* When the character value for '0' is substracted, c should be in the
-           0-9 range, otherwise it is not a decimal number. Because
-           the characer is unsigned no check for < 0 is needed. */
+        /* 0-9 range check. Only one side needs to be checked because of unsigned number */
         c -= '0';
         if (c > 9) {
             if ((i > 0) && ((c + '0') == ':')) {
@@ -1867,9 +1865,7 @@ ssize_t illumina_header_to_tile_id(const uint8_t *header, size_t header_length) 
             }
             return -1;
         }
-        /* The number is read from left to right. The thousands precede the
-           hundreds etc. Whenever a new digit is found the rest of the number
-           can be promoted upwards by multiplying by 10. */
+        /* Shift already found digits one decimal place and add current digit */
         tile_id = tile_id * 10 + c;
     }
     /* No colon found at the end of the string, this is an invalid header */

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1856,18 +1856,15 @@ ssize_t illumina_header_to_tile_id(const uint8_t *header, size_t header_length) 
     size_t remaining_length = header_length - tile_number_offset;
     for (size_t i=0; i < remaining_length; i++) {
         uint8_t c = tile_start[i];
-        if (c == ':') {
-            if (i == 0) {
-                /* Fourth ':' should not be immediately followed by another ':' */
-                return -1;
-            }
-            return tile_id;
-        }
         /* When the character value for '0' is substracted, c should be in the
            0-9 range, otherwise it is not a decimal number. Because
            the characer is unsigned no check for < 0 is needed. */
         c -= '0';
         if (c > 9) {
+            if ((i > 0) && ((c + '0') == ':')) {
+                /* successfully parsed a number between the colons */
+                return tile_id;
+            }
             return -1;
         }
         /* The number is read from left to right. The thousands precede the
@@ -1875,6 +1872,7 @@ ssize_t illumina_header_to_tile_id(const uint8_t *header, size_t header_length) 
            can be promoted upwards by multiplying by 10. */
         tile_id = tile_id * 10 + c;
     }
+    /* No colon found at the end of the string, this is an invalid header */
     return -1;
 }
 

--- a/tests/test_per_tile_quality.py
+++ b/tests/test_per_tile_quality.py
@@ -47,9 +47,17 @@ def test_per_tile_quality_not_view():
     error.match("FastqRecordView")
 
 
-def test_per_tile_quality_skip():
+@pytest.mark.parametrize("header", [
+    "SIMULATED_NAME",
+    "SIM:1:FCX:1::6329:1045:GATTACT+GTCTTAAC 1:N:0:ATCCGA",  # tile empty
+    "SIM:1:FCX:1:abc:6329:1045:GATTACT+GTCTTAAC 1:N:0:ATCCGA",  # tile not a number
+    "SIM:1:FCX:1:0x1a3:6329:1045:GATTACT+GTCTTAAC 1:N:0:ATCCGA",  # number not decimal
+    "SIM:1:FCX:1",  # truncated before tile id
+    "SIM:1:FCX:1:1045",  # truncated after tile id
+])
+def test_per_tile_quality_skip(header):
     read = FastqRecordView(
-        "SIMULATED_NAME",
+        header,
         "AAAA",
         "ABCD"
     )
@@ -57,4 +65,4 @@ def test_per_tile_quality_skip():
     ptq.add_read(read)
     assert ptq.number_of_reads == 0
     assert ptq.max_length == 0
-    assert "SIMULATED_NAME" in ptq.skipped_reason
+    assert header in ptq.skipped_reason

--- a/tests/test_per_tile_quality.py
+++ b/tests/test_per_tile_quality.py
@@ -25,6 +25,21 @@ def test_per_tile_quality():
     assert average_list[3] == 10 ** (-35 / 10)
 
 
+@pytest.mark.parametrize("tile_id", list(range(100)) + [1234, 99239])
+def test_tile_parse_correct(tile_id):
+    read = FastqRecordView(
+        f"SIM:1:FCX:1:{tile_id}:6329:1045:GATTACT+GTCTTAAC 1:N:0:ATCCGA",
+        "AAAA",
+        "ABCD"
+    )
+    ptq = PerTileQuality()
+    ptq.add_read(read)
+    averages = ptq.get_tile_averages()
+    assert len(averages) == 1
+    tile, average_list = averages[0]
+    assert tile == tile_id
+
+
 def test_per_tile_quality_not_view():
     ptq = PerTileQuality()
     with pytest.raises(TypeError) as error:


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

strtol uses lookup tables and this is very fast in general. However if the only requirement is decimal parsing then parsing an ASCII-only string becomes quite easy. The character  values for 0-9 are consecutive in the ASCII alphabet, so the value for 0 can be substracted to give the actual number. If an unsigned variable is used to hold the character the resulting substraction will be greater than 9 if the character is not a valid decimal. 

Not calling strtol and using a very simple mechanism reduces the header parsing time by half. ~100 ms to ~50 ms.
