### PR TITLE
Greatly speed up adapter counter by using out of order execution

### DIFF
--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1670,7 +1670,7 @@ AdapterCounter_add_meta(AdapterCounter *self, struct FastqMeta *meta)
             for (size_t pos=0; pos<sequence_length; pos++) {
                 R1 = _mm_slli_epi64(R1, 1);
                 R2 = _mm_slli_epi64(R2, 1);
-                R1 = _mm_or_si128(R1, init_mask2);
+                R1 = _mm_or_si128(R1, init_mask1);
                 R2 = _mm_or_si128(R2, init_mask2);
                 uint8_t index = NUCLEOTIDE_TO_INDEX[sequence[pos]];
                 __m128i mask1 = bitmasks1[index];

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1663,6 +1663,13 @@ AdapterCounter_add_meta(AdapterCounter *self, struct FastqMeta *meta)
                         pos, R, already_found, matcher, self->adapter_counter);
                 }
             }
+        /* In the cases below we take advantage of out of order execution on the CPU 
+           by checking two matchers at the same time. Either two sse2 matchers, or 
+           a bitmask_t matcher and a vector matcher. Shift-AND is a highly dependent 
+           chain of actions, meaning there is no opportunity for the CPU to do two
+           thing simultaneously. By doing two shift-AND routines at the same time, 
+           there are two independent paths that the CPU can evaluate using out of
+           order execution. This leads to significant speedups. */
         } else if (remaining_vector_matchers == 1 && remaining_scalar_matchers == 1) {
             MachineWordPatternMatcherSSE2 *vector_matcher = self->sse2_matchers + vector_matcher_index;
             MachineWordPatternMatcher *scalar_matcher = self->matchers + scalar_matcher_index;

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1268,10 +1268,8 @@ typedef struct AdapterCounterStruct {
     PyObject *adapters;
     size_t number_of_matchers;
     MachineWordPatternMatcher *matchers;
-#ifdef __SSE2__
     size_t number_of_sse2_matchers;
     MachineWordPatternMatcherSSE2 *sse2_matchers;
-#endif
 } AdapterCounter;
 
 static void AdapterCounter_dealloc(AdapterCounter *self) {
@@ -1440,10 +1438,8 @@ AdapterCounter__new__(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     self->number_of_adapters = number_of_adapters;
     self->number_of_matchers = 0;
     self->number_of_sequences = 0;
-    #ifdef __SSE2__ 
     self->number_of_sse2_matchers = 0;
     self->sse2_matchers = NULL;
-    #endif
     size_t adapter_index = 0;
     size_t matcher_index = 0;
     PyObject *adapter;

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -1269,7 +1269,9 @@ typedef struct AdapterCounterStruct {
     size_t number_of_matchers;
     MachineWordPatternMatcher *matchers;
     size_t number_of_sse2_matchers;
+    #ifdef __SSE2__
     MachineWordPatternMatcherSSE2 *sse2_matchers;
+    #endif
 } AdapterCounter;
 
 static void AdapterCounter_dealloc(AdapterCounter *self) {
@@ -1439,7 +1441,9 @@ AdapterCounter__new__(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     self->number_of_matchers = 0;
     self->number_of_sequences = 0;
     self->number_of_sse2_matchers = 0;
+    #ifdef __SSE2__
     self->sse2_matchers = NULL;
+    #endif
     size_t adapter_index = 0;
     size_t matcher_index = 0;
     PyObject *adapter;

--- a/tests/test_adapter_counter.py
+++ b/tests/test_adapter_counter.py
@@ -80,13 +80,31 @@ def test_adapter_counter_add_read_no_view():
     error.match("bytes")
 
 
-def test_adapter_counter_matcher_multiple_machine_words():
-    adapters = [
+@pytest.mark.parametrize("adapters", [
+    [  # Creates 2 SSE vectors
         "A" * MAX_SEQUENCE_SIZE,
         "C" * MAX_SEQUENCE_SIZE,
         "G" * MAX_SEQUENCE_SIZE,
         "T" * MAX_SEQUENCE_SIZE,
-    ]
+    ],
+    [  # Creates 1 SSE Vector and one 64-bit integer.
+        "A" * MAX_SEQUENCE_SIZE,
+        "C" * MAX_SEQUENCE_SIZE,
+        "G" * MAX_SEQUENCE_SIZE,
+    ],
+    [  # Creates 1 SSE Vector.
+        "A" * MAX_SEQUENCE_SIZE,
+        "C" * MAX_SEQUENCE_SIZE,
+    ],
+    [  # Creates 2 SSE Vectors and one 64-bit integer.
+        "A" * MAX_SEQUENCE_SIZE,
+        "C" * MAX_SEQUENCE_SIZE,
+        "G" * MAX_SEQUENCE_SIZE,
+        "T" * MAX_SEQUENCE_SIZE,
+        "N" * MAX_SEQUENCE_SIZE,
+    ],
+])
+def test_adapter_counter_matcher_multiple_machine_words(adapters):
     sequence = ("GATTACA" * 20).join(adapters)
     read = FastqRecordView("name", sequence, "H" * len(sequence))
     counter = AdapterCounter(adapters)


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

The shift-AND algorithm creates a dependency chain, each computation relies on a result by a former computation. As a result  this is very hard to optimize.

By running two Shift-AND matchers in the same loop, they can be evaluated independently. Modern CPU's can execute these statements out of order leading to simultaneous evaluation. 

The current adapter matching code matches 15 12bp pieces to each sequence when the file is identified as nanopore. That requires three 64-bit integers to store all the pieces. Two of those are combined in a SSE2 vector. Evaluating all the sequencing takes about 650ms on my machine using a 64-bit vector and 850 ms using a SSE2 vector. The total cost for running the routine was thus 850 + 650 ms: roughly 1500 ms.  However thanks to the SSE2 vector and the 64-bit int running simultaneously the cost is now 850 ms, meaning the cost of running the 64-bit integer is entirely negated.

This makes sense from a hardware standpoint as a cpu has 16 general purpose 64 bit registers and 16 vector registers (for x86-64) and can support out of order execution. Nevertheless it is a very impressive result. 

Application performance (all modules!) before:
```
Benchmark 1: sequali ~/test/nanopore_100000reads.fastq
  Time (mean ± σ):      5.633 s ±  0.060 s    [User: 5.339 s, System: 0.293 s]
  Range (min … max):    5.538 s …  5.685 s    5 runs
```

Application performance after:
```
Benchmark 1: sequali ~/test/nanopore_100000reads.fastq
  Time (mean ± σ):      5.086 s ±  0.040 s    [User: 4.805 s, System: 0.279 s]
  Range (min … max):    5.045 s …  5.134 s    5 runs
```

On larger files where the report generation takes less of the total time the improvement is even better. 