### PR TITLE
Add SSSE3 routine for decoding bam sequences

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,11 @@ Installation
 
     pip install git+https://github.com/rhpvorderman/sequali.git
 
+Linux systems on x86_64 will have the SSSE3 instruction set enabled to allow
+faster BAM parsing. This can be disabled with::
+
+    SEQUALI_CPU_BASIC=1 pip install git+https://github.com/rhpvorderman/sequali.git
+
 Usage
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with sequali.  If not, see <https://www.gnu.org/licenses/
 
+import os
+import platform
+import sys
 from pathlib import Path
 
 from setuptools import Extension, find_packages, setup
+
+
+def extra_compile_args():
+    if sys.platform.startswith("linux") and platform.machine() == "x86_64":
+        # SEQUALI_CPU_BASIC=1 pip install --no-binary sequali sequali
+        # Will work for linux users that do not have SSSE3 support.
+        if not os.getenv("SEQUALI_CPU_BASIC"):
+            return ["-mssse3"]
+    # Do not bother with Windows and MacOS as it is not given that they have
+    # a compiler installed. Simply use compatible wheels instead so no users
+    # run into trouble.
+    return None
+
 
 setup(
     name="sequali",
@@ -52,7 +68,9 @@ setup(
     ],
     package_data={'sequali': ['*.c', '*.h', '*.pyi', 'py.typed',
                               'contaminants/*', 'adapters/*']},
-    ext_modules=[Extension("sequali._qc", ["src/sequali/_qcmodule.c"])],
+    ext_modules=[
+        Extension("sequali._qc", ["src/sequali/_qcmodule.c"],
+                  extra_compile_args=extra_compile_args())],
     entry_points={"console_scripts": [
         'sequali=sequali.__main__:main',
         'sequali-report=sequali.__main__:sequali_report'


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

I just saw that ssse3 is a minimum compile target for conda-forge. 