### PR TITLE
Fix tuple unpacking bug by checking the number of parts first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Changelog
 
 version 0.2.0-dev
 -----------------
++ Fixed a crash that occurred in the illumina header checking code on
+  illumina headers without the comment part.
 + ``--max-unique-sequences`` flag replaced with
   ``--overrepresentation-fragment-store-size`` to be consistent with the
   report and other flags.

--- a/src/sequali/util.py
+++ b/src/sequali/util.py
@@ -127,17 +127,29 @@ def guess_sequencing_technology_from_file(fp: io.BufferedReader) -> Optional[str
     return None
 
 
-def fastq_header_is_illumina(header: str):
+def fastq_header_is_illumina(header: str) -> bool:
     # Illumina header format. two parts separated by a space
     # @<instrument>:<run number>:<flowcell ID>:<lane>:<tile>:<x-pos>:<y-pos>
     # <read>:<is filtered>:<control number>:<sample number>
     # See also:
     # https://help.basespace.illumina.com/files-used-by-basespace/fastq-files
-    name, metadata = header.split(maxsplit=1)  # type: str, str
-    if name.count(':') == 6 and metadata.count(':') == 3:
+    header_parts = header.split(maxsplit=1)
+    if len(header_parts) == 1:
+        metadata = None
+    elif len(header_parts) == 2:
+        metadata = header_parts[1]
+    else:
+        return False
+    name = header_parts[0]
+    # Metadata part is not always present, but if it is, it should be tested.
+    if metadata:
+        if metadata.count(':') != 3:
+            return False
         _, is_filtered, _, _ = metadata.split(':')
-        if is_filtered in ("Y", "N"):
-            return True
+        if is_filtered not in ("Y", "N"):
+            return False
+    if name.count(':') == 6:
+        return True
     return False
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,6 +29,7 @@ SAM = DATA / ("project.NIST_NIST7035_H7AP8ADXX_TAAGGCGA_1_NA12878.bwa."
 @pytest.mark.parametrize(["header", "is_illumina"], (
     ("SIM:1:FCX:1:15:6329:1045 1:N:0:2", True),
     ("SIM:1:FCX:1:15:6329:1045 1:Y:0:2", True),
+    ("SIM:1:FCX:1:15:6329:1045", True),
 ))
 def test_fastq_header_is_illumina(header, is_illumina):
     assert fastq_header_is_illumina(header) == is_illumina


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

A bug reported by @marcelm 

```
 Processing reads.2.fastq.gz:   0%|
 
| 0.00/2.65G [00:00<?, ?iB/s]Traceback (most recent call last):
   File ".../scirnaseq/bin/sequali", line 11, in <module>
     sys.exit(main())
   File
".../scirnaseq/lib/python3.10/site-packages/sequali/__main__.py", line
119, in main
     seqtech = guess_sequencing_technology_from_file(file)  # type: ignore
   File ".../scirnaseq/lib/python3.10/site-packages/sequali/util.py",
line 123, in guess_sequencing_technology_from_file
     if fastq_header_is_illumina(header):
   File ".../scirnaseq/lib/python3.10/site-packages/sequali/util.py",
line 136, in fastq_header_is_illumina
     name, metadata = header.split(maxsplit=1)  # type: str, str
ValueError: not enough values to unpack (expected 2, got 1)
Processing reads.2.fastq.gz:   0%|
 
| 0.00/2.65G [00:00<?, ?iB/s]
```

> The first record looks like this:

```
@A00187:967:HCHNLDRX3:1:2101:19108:1047
TCCTCTTCCCATGGCCTGGATAACAAAGGCTTTGTCATCCAGGCCATG
+
FFFFFFFFFF,FFFFFFFFFFFFF:,,FFFFFFFFFFFF:FFFFFFFF
```