### PR TITLE
Use xopen's new functionality to properly open the progressbar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
 
 version 0.6.0-dev
 -----------------
++ The progressbar can track progress through more file formats.
 + The deduplication fingerprint that is used is now configurable from the
   command line.
 + The deduplication module starts by gathering all sequences rather than half

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">3.8"
 dependencies = [
-        "xopen>=1.8.0",
+        "xopen>=2.0.0",
         "pygal>=3.0.4",
         "tqdm",
 ]

--- a/src/sequali/__main__.py
+++ b/src/sequali/__main__.py
@@ -185,8 +185,9 @@ def main() -> None:
     threads = args.threads
     if threads < 1:
         raise ValueError(f"Threads must be greater than 1, got {threads}.")
-    with xopen.xopen(filename, "rb", threads=threads-1) as file:  # type: ignore
-        progress = ProgressUpdater(filename, file)
+    with open(filename, "rb") as raw:
+        progress = ProgressUpdater(raw)
+        file = xopen.xopen(raw, "rb", threads=threads - 1)
         if filename.endswith(".bam") or (
                 hasattr(file, "peek") and file.peek(4)[:4] == b"BAM\1"):
             reader = BamParser(file)

--- a/src/sequali/__main__.py
+++ b/src/sequali/__main__.py
@@ -187,25 +187,25 @@ def main() -> None:
         raise ValueError(f"Threads must be greater than 1, got {threads}.")
     with open(filename, "rb") as raw:
         progress = ProgressUpdater(raw)
-        file = xopen.xopen(raw, "rb", threads=threads - 1)
-        if filename.endswith(".bam") or (
-                hasattr(file, "peek") and file.peek(4)[:4] == b"BAM\1"):
-            reader = BamParser(file)
-            seqtech = guess_sequencing_technology_from_bam_header(reader.header)
-        else:
-            reader = FastqParser(file)  # type: ignore
-            seqtech = guess_sequencing_technology_from_file(file)  # type: ignore
-        adapters = list(adapters_from_file(args.adapter_file, seqtech))
-        adapter_counter = AdapterCounter(adapter.sequence for adapter in adapters)
-        with progress:
-            for record_array in reader:
-                metrics.add_record_array(record_array)
-                per_tile_quality.add_record_array(record_array)
-                adapter_counter.add_record_array(record_array)
-                sequence_duplication.add_record_array(record_array)
-                nanostats.add_record_array(record_array)
-                dedup_estimator.add_record_array(record_array)
-                progress.update(record_array)
+        with xopen.xopen(raw, "rb", threads=threads - 1) as file:
+            if filename.endswith(".bam") or (
+                    hasattr(file, "peek") and file.peek(4)[:4] == b"BAM\1"):
+                reader = BamParser(file)
+                seqtech = guess_sequencing_technology_from_bam_header(reader.header)
+            else:
+                reader = FastqParser(file)  # type: ignore
+                seqtech = guess_sequencing_technology_from_file(file)  # type: ignore
+            adapters = list(adapters_from_file(args.adapter_file, seqtech))
+            adapter_counter = AdapterCounter(adapter.sequence for adapter in adapters)
+            with progress:
+                for record_array in reader:
+                    metrics.add_record_array(record_array)
+                    per_tile_quality.add_record_array(record_array)
+                    adapter_counter.add_record_array(record_array)
+                    sequence_duplication.add_record_array(record_array)
+                    nanostats.add_record_array(record_array)
+                    dedup_estimator.add_record_array(record_array)
+                    progress.update(record_array)
     report_modules = calculate_stats(
         filename,
         metrics,

--- a/src/sequali/util.py
+++ b/src/sequali/util.py
@@ -62,7 +62,7 @@ class ProgressUpdater():
             desc=f"Processing {os.path.basename(filename)}",
             unit="iB", unit_scale=True, unit_divisor=1024,
             total=total,
-            smoothing=0.01,  # Much less erratic than default 0.3
+            smoothing=0.05,  # Much less erratic than default 0.3
         )
 
     def __enter__(self):

--- a/src/sequali/util.py
+++ b/src/sequali/util.py
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with sequali.  If not, see <https://www.gnu.org/licenses/
 
-import gzip
 import io
 import os
 import string
-from typing import (BinaryIO, Callable, Iterator, List, Optional, SupportsIndex,
-                    Tuple)
+from typing import Callable, Iterator, List, Optional, SupportsIndex, Tuple
 
 import tqdm
 
@@ -48,18 +46,14 @@ class ProgressUpdater():
     next_update_at: int
     tqdm: tqdm.tqdm
 
-    def __init__(self, filename, filereader: BinaryIO):
+    def __init__(self, filereader: io.BufferedReader):
         self.previous_file_pos = 0
         self.current_processed_bytes = 0
         self.progress_update_every = 1024 * 1024 * 10
         self.next_update_at = self.progress_update_every
+        filename = filereader.name
         total: Optional[int] = os.stat(filename).st_size
-        if isinstance(filereader, gzip.GzipFile):
-            self._get_position = filereader.fileobj.tell
-        elif (isinstance(filereader, io.BufferedReader) and
-                isinstance(filereader.raw, _ThreadedGzipReader)):
-            self._get_position = filereader.raw.raw.tell
-        elif filereader.seekable():
+        if filereader.seekable():
             self._get_position = filereader.tell
         else:
             self._get_position = lambda: self.current_processed_bytes


### PR DESCRIPTION
This switches from pulling the original file object from loads of private variables to simply creating the file object and passing it to xopen. The progressbar is now available for all file types that xopen can open. 

@marcelm, FYI. xopen 2.0.0 now allows tracking the progress through the file while it is decompressed by this pattern. Tqdm is quite a nice library, it has no dependencies. Maybe useful for the cutadapt progressbar some day?

### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
