### PR TITLE
Prevent cache pollution by using non-temporal hints for count arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.8.0-dev
+-----------------
++ Minor performance improvement by providing a non-temporal cache hint in the
+  QCMetrics module.
+
 version 0.7.1
 -----------------
 + Fix a small visual bug in the report sidebar.


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [x] Documentation was updated (if needed)

Leads to a small but measurable performance gain on illumina reads.