### PR TITLE
Only sample the read extremities rather than the entire read to prevent a lot of false positive overrepresented sequences.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 0.13.0-dev
+------------------
++ Only sample the first 100 bp from the beginning and end of the read by
+  default for the overrepresented sequences analysis. This prevents a lot of
+  false positives from common human genome repeats. The amount of base pairs
+  that are sampled from the beginning and end is user settable with an option
+  to sample everything.
+
 version 0.12.0
 ------------------
 + Properly name percentiles as such in the sequence length distribution rather

--- a/src/sequali/__init__.py
+++ b/src/sequali/__init__.py
@@ -17,7 +17,7 @@
 from ._qc import A, C, G, N, T
 from ._qc import (
     AdapterCounter, BamParser, FastqParser, FastqRecordArrayView,
-    FastqRecordView, PerTileQuality, QCMetrics, SequenceDuplication
+    FastqRecordView, OverrepresentedSequences, PerTileQuality, QCMetrics,
 )
 from ._qc import NUMBER_OF_NUCS, NUMBER_OF_PHREDS, PHRED_MAX, TABLE_SIZE
 from ._version import __version__
@@ -32,7 +32,7 @@ __all__ = [
     "FastqRecordArrayView",
     "PerTileQuality",
     "QCMetrics",
-    "SequenceDuplication",
+    "OverrepresentedSequences",
     "NUMBER_OF_NUCS",
     "NUMBER_OF_PHREDS",
     "PHRED_MAX",

--- a/src/sequali/__main__.py
+++ b/src/sequali/__main__.py
@@ -23,6 +23,8 @@ import sys
 
 from ._qc import (
     AdapterCounter,
+    DEFAULT_BASES_FROM_END,
+    DEFAULT_BASES_FROM_START,
     DEFAULT_DEDUP_MAX_STORED_FINGERPRINTS,
     DEFAULT_FINGERPRINT_BACK_SEQUENCE_LENGTH,
     DEFAULT_FINGERPRINT_BACK_SEQUENCE_OFFSET,
@@ -119,6 +121,20 @@ def argument_parser() -> argparse.ArgumentParser:
                              f"gets filled up with more sequences from the "
                              f"beginning. "
                              f"Default: 1 in {DEFAULT_UNIQUE_SAMPLE_EVERY}.")
+    parser.add_argument("--overrepresentation-bases-from-start", type=int,
+                        default=DEFAULT_BASES_FROM_START,
+                        metavar="BP",
+                        help=f"The minimum amount of bases sampled from the "
+                             f"start of the read. There might be slight overshoot "
+                             f"depending on the fragment length. "
+                             f"Default: {DEFAULT_BASES_FROM_START}")
+    parser.add_argument("--overrepresentation-bases-from-end", type=int,
+                        default=DEFAULT_BASES_FROM_END,
+                        metavar="BP",
+                        help=f"The minimum amount of bases sampled from the "
+                             f"end of the read. There might be slight overshoot "
+                             f"depending on the fragment length. "
+                             f"Default: {DEFAULT_BASES_FROM_END}")
     parser.add_argument("--duplication-max-stored-fingerprints", type=int,
                         default=DEFAULT_DEDUP_MAX_STORED_FINGERPRINTS,
                         metavar="N",

--- a/src/sequali/__main__.py
+++ b/src/sequali/__main__.py
@@ -126,14 +126,16 @@ def argument_parser() -> argparse.ArgumentParser:
                         metavar="BP",
                         help=f"The minimum amount of bases sampled from the "
                              f"start of the read. There might be slight overshoot "
-                             f"depending on the fragment length. "
+                             f"depending on the fragment length. Set to a "
+                             f"negative value to sample the entire read. "
                              f"Default: {DEFAULT_BASES_FROM_START}")
     parser.add_argument("--overrepresentation-bases-from-end", type=int,
                         default=DEFAULT_BASES_FROM_END,
                         metavar="BP",
                         help=f"The minimum amount of bases sampled from the "
                              f"end of the read. There might be slight overshoot "
-                             f"depending on the fragment length. "
+                             f"depending on the fragment length. Set to a "
+                             f"negative value to sample the entire read. "
                              f"Default: {DEFAULT_BASES_FROM_END}")
     parser.add_argument("--duplication-max-stored-fingerprints", type=int,
                         default=DEFAULT_DEDUP_MAX_STORED_FINGERPRINTS,

--- a/src/sequali/__main__.py
+++ b/src/sequali/__main__.py
@@ -34,9 +34,9 @@ from ._qc import (
     DedupEstimator,
     InsertSizeMetrics,
     NanoStats,
+    OverrepresentedSequences,
     PerTileQuality,
     QCMetrics,
-    SequenceDuplication
 )
 from ._version import __version__
 from .adapters import DEFAULT_ADAPTER_FILE, adapters_from_file
@@ -188,7 +188,7 @@ def main() -> None:
     metrics1 = QCMetrics()
     per_tile_quality1 = PerTileQuality()
     nanostats1 = NanoStats()
-    sequence_duplication1 = SequenceDuplication(
+    overrepresented_sequences1 = OverrepresentedSequences(
         max_unique_fragments=args.overrepresentation_max_unique_fragments,
         fragment_length=args.overrepresentation_fragment_length,
         sample_every=args.overrepresentation_sample_every
@@ -219,7 +219,7 @@ def main() -> None:
         insert_size_metrics = InsertSizeMetrics()
         metrics2 = QCMetrics()
         per_tile_quality2 = PerTileQuality()
-        sequence_duplication2 = SequenceDuplication(
+        overrepresented_sequences2 = OverrepresentedSequences(
             max_unique_fragments=args.overrepresentation_max_unique_fragments,
             fragment_length=args.overrepresentation_fragment_length,
             sample_every=args.overrepresentation_sample_every
@@ -227,7 +227,7 @@ def main() -> None:
     else:
         metrics2 = None
         per_tile_quality2 = None
-        sequence_duplication2 = None
+        overrepresented_sequences2 = None
         insert_size_metrics = None
     with contextlib.ExitStack() as exit_stack:
         reader1 = NGSFile(args.input, threads - 1)
@@ -253,7 +253,7 @@ def main() -> None:
         for record_array1 in reader1:
             metrics1.add_record_array(record_array1)
             per_tile_quality1.add_record_array(record_array1)
-            sequence_duplication1.add_record_array(record_array1)
+            overrepresented_sequences1.add_record_array(record_array1)
             nanostats1.add_record_array(record_array1)
             if paired:
                 record_array2 = reader2.read(len(record_array1))
@@ -274,7 +274,7 @@ def main() -> None:
                 insert_size_metrics.add_record_array_pair(record_array1, record_array2)  # type: ignore  # noqa: E501
                 metrics2.add_record_array(record_array2)  # type: ignore  # noqa: E501
                 per_tile_quality2.add_record_array(record_array2)  # type: ignore  # noqa: E501
-                sequence_duplication2.add_record_array(record_array2)  # type: ignore  # noqa: E501
+                overrepresented_sequences2.add_record_array(record_array2)  # type: ignore  # noqa: E501
             else:
                 adapter_counter1.add_record_array(record_array1)   # type: ignore  # noqa: E501
                 dedup_estimator.add_record_array(record_array1)
@@ -289,14 +289,14 @@ def main() -> None:
         metrics=metrics1,
         adapter_counter=adapter_counter1,
         per_tile_quality=per_tile_quality1,
-        sequence_duplication=sequence_duplication1,
+        sequence_duplication=overrepresented_sequences1,
         dedup_estimator=dedup_estimator,
         nanostats=nanostats1,
         insert_size_metrics=insert_size_metrics,
         filename_reverse=args.input_reverse,
         metrics_reverse=metrics2,
         per_tile_quality_reverse=per_tile_quality2,
-        sequence_duplication_reverse=sequence_duplication2,
+        sequence_duplication_reverse=overrepresented_sequences2,
         adapters=adapters,
         fraction_threshold=fraction_threshold,
         min_threshold=min_threshold,

--- a/src/sequali/_qc.pyi
+++ b/src/sequali/_qc.pyi
@@ -32,6 +32,8 @@ DEFAULT_MAX_UNIQUE_FRAGMENTS: int
 DEFAULT_DEDUP_MAX_STORED_FINGERPRINTS: int
 DEFAULT_FRAGMENT_LENGTH: int
 DEFAULT_UNIQUE_SAMPLE_EVERY: int
+DEFAULT_BASES_FROM_START: int
+DEFAULT_BASES_FROM_END: int
 DEFAULT_FINGERPRINT_FRONT_SEQUENCE_LENGTH: int
 DEFAULT_FINGERPRINT_BACK_SEQUENCE_LENGTH: int
 DEFAULT_FINGERPRINT_FRONT_SEQUENCE_OFFSET: int
@@ -106,7 +108,10 @@ class OverrepresentedSequences:
     def __init__(self,
                  max_unique_fragments: int = DEFAULT_MAX_UNIQUE_FRAGMENTS,
                  fragment_length: int = DEFAULT_FRAGMENT_LENGTH,
-                 sample_every: int = DEFAULT_UNIQUE_SAMPLE_EVERY): ...
+                 sample_every: int = DEFAULT_UNIQUE_SAMPLE_EVERY,
+                 bases_from_start: int = DEFAULT_BASES_FROM_START,
+                 bases_from_end = DEFAULT_BASES_FROM_END,
+    ): ...
     def add_read(self, __read: FastqRecordView) -> None: ...
     def add_record_array(self, __record_array: FastqRecordArrayView) -> None: ...
     def sequence_counts(self) -> Dict[str, int]: ...

--- a/src/sequali/_qc.pyi
+++ b/src/sequali/_qc.pyi
@@ -94,7 +94,7 @@ class PerTileQuality:
     def add_record_array(self, __record_array: FastqRecordArrayView) -> None: ...
     def get_tile_counts(self) -> List[Tuple[int, List[float], List[int]]]: ...
 
-class SequenceDuplication:
+class OverrepresentedSequences:
     number_of_sequences: int
     sampled_sequences: int
     collected_unique_fragments: int

--- a/src/sequali/_qcmodule.c
+++ b/src/sequali/_qcmodule.c
@@ -3193,9 +3193,9 @@ OverrepresentedSequences__new__(PyTypeObject *type, PyObject *args, PyObject *kw
                                  "sample_every",         "bases_from_start",
                                  "bases_from_end",       NULL};
     static char *format = "|nnnnn:OverrepresentedSequences";
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, kwargnames,
-                                     &max_unique_fragments, &fragment_length,
-                                     &sample_every)) {
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwargs, format, kwargnames, &max_unique_fragments,
+            &fragment_length, &sample_every, &bases_from_start, &bases_from_end)) {
         return NULL;
     }
     if (max_unique_fragments < 1) {
@@ -3216,10 +3216,10 @@ OverrepresentedSequences__new__(PyTypeObject *type, PyObject *args, PyObject *kw
                      "sample_every must be 1 or greater. Got %zd", sample_every);
         return NULL;
     }
-    if (bases_from_start < 1) {
+    if (bases_from_start < 0) {
         bases_from_start = UINT32_MAX;
     }
-    if (bases_from_end < 1) {
+    if (bases_from_end < 0) {
         bases_from_end = UINT32_MAX;
     }
     /* If size is a power of 2, the modulo HASH_TABLE_SIZE can be optimised to

--- a/src/sequali/report_modules.py
+++ b/src/sequali/report_modules.py
@@ -35,9 +35,16 @@ import pygal  # type: ignore
 import pygal.style  # type: ignore
 
 from ._qc import A, C, G, N, T
-from ._qc import (AdapterCounter, DedupEstimator,
-                  INSERT_SIZE_MAX_ADAPTER_STORE_SIZE, InsertSizeMetrics,
-                  NanoStats, PerTileQuality, QCMetrics, SequenceDuplication)
+from ._qc import (
+    AdapterCounter,
+    DedupEstimator,
+    INSERT_SIZE_MAX_ADAPTER_STORE_SIZE,
+    InsertSizeMetrics,
+    NanoStats,
+    OverrepresentedSequences,
+    PerTileQuality,
+    QCMetrics,
+)
 from ._qc import NUMBER_OF_NUCS, NUMBER_OF_PHREDS, PHRED_MAX
 from ._version import __version__
 from .adapters import Adapter
@@ -1495,7 +1502,7 @@ class OverRepresentedSequences(ReportModule):
     @classmethod
     def from_sequence_duplication(
             cls,
-            seqdup: SequenceDuplication,
+            seqdup: OverrepresentedSequences,
             fraction_threshold: float = DEFAULT_FRACTION_THRESHOLD,
             min_threshold: int = DEFAULT_MIN_THRESHOLD,
             max_threshold: int = DEFAULT_MAX_THRESHOLD,
@@ -2131,7 +2138,7 @@ def calculate_stats(
         filename: str,
         metrics: QCMetrics,
         per_tile_quality: PerTileQuality,
-        sequence_duplication: SequenceDuplication,
+        sequence_duplication: OverrepresentedSequences,
         dedup_estimator: DedupEstimator,
         nanostats: NanoStats,
         adapters: List[Adapter],
@@ -2140,7 +2147,7 @@ def calculate_stats(
         insert_size_metrics: Optional[InsertSizeMetrics] = None,
         metrics_reverse: Optional[QCMetrics] = None,
         per_tile_quality_reverse: Optional[PerTileQuality] = None,
-        sequence_duplication_reverse: Optional[SequenceDuplication] = None,
+        sequence_duplication_reverse: Optional[OverrepresentedSequences] = None,
         graph_resolution: int = 200,
         fraction_threshold: float = DEFAULT_FRACTION_THRESHOLD,
         min_threshold: int = DEFAULT_MIN_THRESHOLD,

--- a/tests/test_overrepresented_sequences.py
+++ b/tests/test_overrepresented_sequences.py
@@ -30,7 +30,7 @@ def view_from_sequence(sequence: str) -> FastqRecordView:
     )
 
 
-def test_sequence_duplication():
+def test_overrepresented_sequences():
     max_unique_fragments = 100_000
     fragment_length = 31
     seqdup = OverrepresentedSequences(
@@ -60,7 +60,7 @@ def test_sequence_duplication():
     assert sequence_counts[fragment_length * "A"] == 2
 
 
-def test_sequence_duplication_add_read_no_view():
+def test_overrepresented_sequences_add_read_no_view():
     seqs = OverrepresentedSequences()
     with pytest.raises(TypeError) as error:
         seqs.add_read(b"ACGT")  # type: ignore
@@ -69,7 +69,8 @@ def test_sequence_duplication_add_read_no_view():
 
 
 @pytest.mark.parametrize("threshold", [-0.1, 1.1])
-def test_sequence_duplication_overrepresented_sequences_faulty_threshold(threshold):
+def test_overrepresented_sequences_overrepresented_sequences_faulty_threshold(
+        threshold):
     seqs = OverrepresentedSequences()
     with pytest.raises(ValueError) as error:
         seqs.overrepresented_sequences(threshold_fraction=threshold)
@@ -79,7 +80,7 @@ def test_sequence_duplication_overrepresented_sequences_faulty_threshold(thresho
     error.match("1.0")
 
 
-def test_sequence_duplication_overrepresented_sequences():
+def test_overrepresented_sequences_overrepresented_sequences():
     fragment_length = 31
     seqs = OverrepresentedSequences(sample_every=1, fragment_length=fragment_length)
     for i in range(100):
@@ -118,7 +119,7 @@ def test_sequence_duplication_overrepresented_sequences():
     assert overrepresented[1][2] == "C" * fragment_length
 
 
-def test_sequence_duplication_case_insensitive():
+def test_overrepresented_sequences_case_insensitive():
     fragment_length = 31
     seqs = OverrepresentedSequences(fragment_length=fragment_length, sample_every=1)
     seqs.add_read(view_from_sequence("aaTTaca" * 5))
@@ -133,7 +134,7 @@ def test_sequence_duplication_case_insensitive():
 
 
 @pytest.mark.parametrize("divisor", list(range(1, 21)))
-def test_sequence_duplication_sampling_rate(divisor):
+def test_overrepresented_sequences_sampling_rate(divisor):
     seqs = OverrepresentedSequences(sample_every=divisor)
     read = view_from_sequence("AAAA")
     number_of_sequences = 10_000
@@ -151,7 +152,7 @@ def test_sequence_duplication_sampling_rate(divisor):
     # Fragments that are duplicated in the sequence should only be recorded once.
     ("GATTACGATTAC", {"ATC": 1, "GTA": 1}),
 ])
-def test_sequence_duplication_all_fragments(sequence, result):
+def test_overrepresented_sequences_all_fragments(sequence, result):
     seqs = OverrepresentedSequences(fragment_length=3, sample_every=1)
     seqs.add_read(view_from_sequence(sequence))
     seq_counts = seqs.sequence_counts()

--- a/tests/test_overrepresented_sequences.py
+++ b/tests/test_overrepresented_sequences.py
@@ -179,3 +179,30 @@ def test_valid_does_not_warn_for_n():
         seqs.add_read(view_from_sequence("ACGTN"))
     # N does lead to a sample not being loaded.
     assert seqs.sampled_sequences == 1
+
+
+@pytest.mark.parametrize(
+    ["bases_from_start", "bases_from_end", "result"], [
+        (0, 0, ()),
+        (1, 1, ("AAC", "CAA")),
+        (2, 2, ("AAC", "CAA")),
+        (3, 3, ("AAC", "CAA")),
+        (4, 4, ("AAC", "CAA", "CCG", "GCC")),
+        (1, 0, ("AAC",)),
+        (0, 1, ("CAA",)),
+        (100, 100, ("AAA", "AAC", "CAA", "CCG", "GCC")),
+        (-1, -1, ("AAA", "AAC", "CAA", "CCG", "GCC")),
+    ]
+)
+def test_overrepresented_sequences_sample_from_begin_and_end(
+        bases_from_start, bases_from_end, result):
+    seqs = OverrepresentedSequences(
+        fragment_length=3,
+        sample_every=1,
+        bases_from_start=bases_from_start,
+        bases_from_end=bases_from_end
+    )
+    seqs.add_read(view_from_sequence("AACCGGTTTTGGCCAA"))
+    overrepresented = [x[2] for x in seqs.overrepresented_sequences(min_threshold=1)]
+    overrepresented.sort()
+    assert tuple(overrepresented) == result

--- a/tests/test_sequence_duplication.py
+++ b/tests/test_sequence_duplication.py
@@ -19,7 +19,7 @@ import warnings
 
 import pytest
 
-from sequali import FastqRecordView, SequenceDuplication
+from sequali import FastqRecordView, OverrepresentedSequences
 
 
 def view_from_sequence(sequence: str) -> FastqRecordView:
@@ -33,9 +33,11 @@ def view_from_sequence(sequence: str) -> FastqRecordView:
 def test_sequence_duplication():
     max_unique_fragments = 100_000
     fragment_length = 31
-    seqdup = SequenceDuplication(max_unique_fragments=max_unique_fragments,
-                                 fragment_length=fragment_length,
-                                 sample_every=1)
+    seqdup = OverrepresentedSequences(
+        max_unique_fragments=max_unique_fragments,
+        fragment_length=fragment_length,
+        sample_every=1
+    )
     # Create unique sequences by using all combinations of ACGT for the amount
     # of letters that is necessary to completely saturate the maximum unique
     # sequences
@@ -59,18 +61,18 @@ def test_sequence_duplication():
 
 
 def test_sequence_duplication_add_read_no_view():
-    seqdup = SequenceDuplication()
+    seqs = OverrepresentedSequences()
     with pytest.raises(TypeError) as error:
-        seqdup.add_read(b"ACGT")  # type: ignore
+        seqs.add_read(b"ACGT")  # type: ignore
     error.match("FastqRecordView")
     error.match("bytes")
 
 
 @pytest.mark.parametrize("threshold", [-0.1, 1.1])
 def test_sequence_duplication_overrepresented_sequences_faulty_threshold(threshold):
-    seqdup = SequenceDuplication()
+    seqs = OverrepresentedSequences()
     with pytest.raises(ValueError) as error:
-        seqdup.overrepresented_sequences(threshold_fraction=threshold)
+        seqs.overrepresented_sequences(threshold_fraction=threshold)
     error.match(str(threshold))
     error.match("between")
     error.match("0.0")
@@ -79,20 +81,20 @@ def test_sequence_duplication_overrepresented_sequences_faulty_threshold(thresho
 
 def test_sequence_duplication_overrepresented_sequences():
     fragment_length = 31
-    seqdup = SequenceDuplication(sample_every=1, fragment_length=fragment_length)
+    seqs = OverrepresentedSequences(sample_every=1, fragment_length=fragment_length)
     for i in range(100):
-        seqdup.add_read(view_from_sequence("A" * fragment_length))
+        seqs.add_read(view_from_sequence("A" * fragment_length))
     for i in range(200):
-        seqdup.add_read(view_from_sequence("C" * fragment_length))
+        seqs.add_read(view_from_sequence("C" * fragment_length))
     for i in range(2000):
-        seqdup.add_read(view_from_sequence("G" * fragment_length))
+        seqs.add_read(view_from_sequence("G" * fragment_length))
     for i in range(10):
-        seqdup.add_read(view_from_sequence("T" * fragment_length))
-    seqdup.add_read(view_from_sequence("C" * (fragment_length - 1) + "A"))
+        seqs.add_read(view_from_sequence("T" * fragment_length))
+    seqs.add_read(view_from_sequence("C" * (fragment_length - 1) + "A"))
     for i in range(100_000 - (100 + 200 + 2000 + 10 + 1)):
         # Count up to 100_000 to get nice fractions for all the sequences
-        seqdup.add_read(view_from_sequence("A" * (fragment_length - 1) + "C"))
-    overrepresented = seqdup.overrepresented_sequences(threshold_fraction=0.001)
+        seqs.add_read(view_from_sequence("A" * (fragment_length - 1) + "C"))
+    overrepresented = seqs.overrepresented_sequences(threshold_fraction=0.001)
     assert overrepresented[0][2] == "A" * (fragment_length - 1) + "C"
     assert overrepresented[1][2] == "C" * fragment_length
     assert overrepresented[1][0] == 2200
@@ -100,14 +102,14 @@ def test_sequence_duplication_overrepresented_sequences():
     assert overrepresented[2][1] == 110 / 100_000
     # Assert no other sequences recorded as overrepresented.
     assert len(overrepresented) == 3
-    overrepresented = seqdup.overrepresented_sequences(threshold_fraction=0.00001)
+    overrepresented = seqs.overrepresented_sequences(threshold_fraction=0.00001)
     assert overrepresented[-1][2] == "C" * (fragment_length - 1) + "A"
-    overrepresented = seqdup.overrepresented_sequences(
+    overrepresented = seqs.overrepresented_sequences(
         threshold_fraction=0.00001,
         min_threshold=2,
     )
     assert overrepresented[-1][2] == "A" * fragment_length
-    overrepresented = seqdup.overrepresented_sequences(
+    overrepresented = seqs.overrepresented_sequences(
         threshold_fraction=0.1,
         min_threshold=2,
         max_threshold=1000,
@@ -118,13 +120,13 @@ def test_sequence_duplication_overrepresented_sequences():
 
 def test_sequence_duplication_case_insensitive():
     fragment_length = 31
-    seqdup = SequenceDuplication(fragment_length=fragment_length, sample_every=1)
-    seqdup.add_read(view_from_sequence("aaTTaca" * 5))
-    seqdup.add_read(view_from_sequence("AAttACA" * 5))
-    seqcounts = seqdup.sequence_counts()
-    assert seqdup.number_of_sequences == 2
-    assert seqdup.total_fragments == 4
-    assert seqdup.collected_unique_fragments == 2
+    seqs = OverrepresentedSequences(fragment_length=fragment_length, sample_every=1)
+    seqs.add_read(view_from_sequence("aaTTaca" * 5))
+    seqs.add_read(view_from_sequence("AAttACA" * 5))
+    seqcounts = seqs.sequence_counts()
+    assert seqs.number_of_sequences == 2
+    assert seqs.total_fragments == 4
+    assert seqs.collected_unique_fragments == 2
     assert len(seqcounts) == 2
     assert seqcounts[("AATTACA" * 5)[:fragment_length]] == 2
     assert seqcounts[("AATTACA" * 5)[-fragment_length:]] == 2
@@ -132,13 +134,13 @@ def test_sequence_duplication_case_insensitive():
 
 @pytest.mark.parametrize("divisor", list(range(1, 21)))
 def test_sequence_duplication_sampling_rate(divisor):
-    seqdup = SequenceDuplication(sample_every=divisor)
+    seqs = OverrepresentedSequences(sample_every=divisor)
     read = view_from_sequence("AAAA")
     number_of_sequences = 10_000
     for i in range(number_of_sequences):
-        seqdup.add_read(read)
-    assert seqdup.number_of_sequences == number_of_sequences
-    assert seqdup.sampled_sequences == (number_of_sequences + divisor - 1) // divisor
+        seqs.add_read(read)
+    assert seqs.number_of_sequences == number_of_sequences
+    assert seqs.sampled_sequences == (number_of_sequences + divisor - 1) // divisor
 
 
 @pytest.mark.parametrize(["sequence", "result"], [
@@ -150,29 +152,29 @@ def test_sequence_duplication_sampling_rate(divisor):
     ("GATTACGATTAC", {"ATC": 1, "GTA": 1}),
 ])
 def test_sequence_duplication_all_fragments(sequence, result):
-    seqdup = SequenceDuplication(fragment_length=3, sample_every=1)
-    seqdup.add_read(view_from_sequence(sequence))
-    seq_counts = seqdup.sequence_counts()
+    seqs = OverrepresentedSequences(fragment_length=3, sample_every=1)
+    seqs.add_read(view_from_sequence(sequence))
+    seq_counts = seqs.sequence_counts()
     assert seq_counts == result
 
 
 def test_very_short_sequence():
     # With 32 byte load this will overflow the used memory.
-    seqdup = SequenceDuplication(fragment_length=3, sample_every=1)
-    seqdup.add_read(view_from_sequence("ACT"))
-    assert seqdup.sequence_counts() == {"ACT": 1}
+    seqs = OverrepresentedSequences(fragment_length=3, sample_every=1)
+    seqs.add_read(view_from_sequence("ACT"))
+    assert seqs.sequence_counts() == {"ACT": 1}
 
 
 def test_non_iupac_warning():
-    seqdup = SequenceDuplication(fragment_length=3, sample_every=1)
+    seqs = OverrepresentedSequences(fragment_length=3, sample_every=1)
     with pytest.warns(UserWarning, match="KKK"):
-        seqdup.add_read(view_from_sequence("KKK"))
+        seqs.add_read(view_from_sequence("KKK"))
 
 
 def test_valid_does_not_warn_for_n():
-    seqdup = SequenceDuplication(fragment_length=3, sample_every=1)
+    seqs = OverrepresentedSequences(fragment_length=3, sample_every=1)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        seqdup.add_read(view_from_sequence("ACGTN"))
+        seqs.add_read(view_from_sequence("ACGTN"))
     # N does lead to a sample not being loaded.
-    assert seqdup.sampled_sequences == 1
+    assert seqs.sampled_sequences == 1


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
